### PR TITLE
Fixed last_download sensor to publish ISO timestamp as state

### DIFF
--- a/include/ha_entities.h
+++ b/include/ha_entities.h
@@ -24,6 +24,7 @@ struct entity_t {
     const char *availability_topic;
     const char *command_topic;
     const char *icon;
+    const char *device_class;
     const char *value_template;
     const char *json_attributes_topic;
     const char *json_attributes_template;

--- a/include/ha_status.h
+++ b/include/ha_status.h
@@ -54,6 +54,17 @@ void status_set_preset_selected(const char *preset);
 void status_set_custom_directory(const char *directory);
 
 /**
+ * @brief Set the information about the last profile download, including the directory it was downloaded to, 
+ *        the final path, and a timestamp. This is used for informational purposes and does not necessarily 
+ *        need to match any actual directory or timestamp.
+ * 
+ * @param directory 
+ * @param path 
+ * @param timestamp 
+ */
+void status_set_last_download(const char *directory, const char *path, const char *timestamp);
+
+/**
  * @brief Set the availability status.
  * 
  * @param available true if available, false if not

--- a/include/unifi_profiles_repo.h
+++ b/include/unifi_profiles_repo.h
@@ -53,14 +53,17 @@ bool profiles_repo_create_temp_profile_dir(char *out_dir, size_t out_len);
  *        subdirectory to indicate an incomplete download. Otherwise, it will be moved to a "downloads" subdirectory. 
  *        The final path will be returned in out.
  * 
- * @param temp_dir 
+ * @param temp_dir
+ * @param time 
  * @param partial 
- * @param out 
- * @param out_len 
+ * @param out_dir
+ * @param out_dir_len
+ * @param out_path
+ * @param out_path_len
  * @return true 
  * @return false 
  */
-bool profiles_repo_rename_temp_profile_dir(const char *temp_dir, bool partial, char *out, size_t out_len);
+bool profiles_repo_rename_temp_profile_dir(const char *temp_dir, time_t *time, bool partial, char *out_dir, size_t out_dir_len, char *out_path, size_t out_path_len);
 
 /**
  * @brief Write the last applied profile information to storage. This can be used to track which profile was last applied,

--- a/include/utils.h
+++ b/include/utils.h
@@ -2,6 +2,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <time.h>
 
 /**
  * @brief Check if a file exists at the given path.
@@ -65,13 +66,22 @@ bool utils_write_file(const char *path, const char *content);
 bool utils_create_directory(const char *path);
 
 /**
- * @brief Build a timestamp string in the format "YYYYMMDD-HHMMSS".
+ * @brief Build a timestamp string in the format "YYYYMMDD_HHMMSS" for the current time or a given time.
  * 
- * @param out output buffer
- * @param out_size size of the output buffer
+ * @param t 
+ * @param out 
+ * @param out_size 
  */
-void utils_build_timestamp(char *out, size_t out_size);
+void utils_build_timestamp_dir(time_t *t, char *out, size_t out_size);
 
+/**
+ * @brief Build a timestamp string in ISO 8601 format (e.g. "2024-06-01T12:34:56Z") for the current time or a given time.
+ * 
+ * @param t 
+ * @param out 
+ * @param out_size 
+ */
+void utils_build_iso_timestamp(time_t *t, char *out, size_t out_size);
 
 /**
  * @brief Convert a string to human readable format.

--- a/src/ha_discovery.c
+++ b/src/ha_discovery.c
@@ -97,6 +97,10 @@ static bool build_entity_payload(char *payload, size_t payload_size, const entit
 
     cJSON_AddStringToObject(root, "icon", d->icon);
 
+    if (d->device_class) {
+        cJSON_AddStringToObject(root, "device_class", d->device_class);
+    }
+
     if (d->value_template) {
         cJSON_AddStringToObject(root, "value_template", d->value_template);
     }

--- a/src/ha_entities.c
+++ b/src/ha_entities.c
@@ -36,6 +36,7 @@ const entity_t HA_ENTITIES[]  = {
         .availability_topic = "availability",
         .command_topic = NULL,
         .icon = "mdi:information-outline",
+        .device_class = NULL,
         .add_options = NULL,
         .handle_command = NULL
     }, {
@@ -47,6 +48,7 @@ const entity_t HA_ENTITIES[]  = {
         .availability_topic = "availability",
         .command_topic = NULL,
         .icon = "mdi:alert-circle-outline",
+        .device_class = NULL,
         .value_template = "{{ value_json.message }}",
         .json_attributes_topic = "last_error",
         .json_attributes_template = NULL,
@@ -61,6 +63,7 @@ const entity_t HA_ENTITIES[]  = {
         .availability_topic ="availability",
         .command_topic = NULL,
         .icon = "mdi:badge-account",
+        .device_class = NULL,
         .add_options = NULL,
         .handle_command = NULL
     }, {
@@ -72,6 +75,7 @@ const entity_t HA_ENTITIES[]  = {
         .availability_topic ="availability",
         .command_topic = "cmd/preset_set",
         .icon = "mdi:tune-variant",
+        .device_class = NULL,
         .add_options = add_preset_options,
         .handle_command = command_set_preset
     }, {
@@ -83,6 +87,7 @@ const entity_t HA_ENTITIES[]  = {
         .availability_topic ="availability",
         .command_topic = "cmd/apply_custom",
         .icon = "mdi:folder",
+        .device_class = NULL,
         .add_options = NULL,
         .handle_command = command_apply_custom
     }, {
@@ -94,6 +99,7 @@ const entity_t HA_ENTITIES[]  = {
         .availability_topic = "availability",
         .command_topic = "cmd/test_config",
         .icon = "mdi:test-tube",
+        .device_class = NULL,
         .add_options = NULL,
         .handle_command = command_test_config
     }, {
@@ -105,17 +111,22 @@ const entity_t HA_ENTITIES[]  = {
         .availability_topic = "availability",
         .command_topic = "cmd/download_assets",
         .icon = "mdi:download",
+        .device_class = NULL,
         .add_options = NULL,
         .handle_command = command_download_assets
     }, {
         .component = "sensor",
-        .object_id = "last_download_path",
+        .object_id = "last_download",
         .name = "Last Asset Download",
         .category = "diagnostic",
-        .state_topic = "download/last_path",
+        .state_topic = "last_download/time/state",
         .availability_topic = "availability",
         .command_topic = NULL,
         .icon = "mdi:folder-arrow-down",
+        .device_class = "timestamp",
+        .value_template = NULL,
+        .json_attributes_topic = "last_download/time/attributes",
+        .json_attributes_template = NULL,
         .add_options = NULL,
         .handle_command = NULL
     }

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -183,7 +183,7 @@ void mqtt_publish(const char *topic, const char *payload, int qos, int retained)
         return;
     }
     
-    LOG_INFO("Published -> %s", topic);
+    LOG_INFO("Published '%s' -> %s", payload, topic);
 }
 
 void mqtt_loop(int timeout_ms) {

--- a/src/unifi_profiles_repo.c
+++ b/src/unifi_profiles_repo.c
@@ -149,7 +149,7 @@ bool profiles_repo_create_temp_profile_dir(char *out_dir, size_t out_len) {
     return true;
 }
 
-bool profiles_repo_rename_temp_profile_dir(const char *temp_dir, bool partial, char *out, size_t out_len) {
+bool profiles_repo_rename_temp_profile_dir(const char *temp_dir, time_t *time, bool partial, char *out_dir, size_t out_dir_len, char *out_path, size_t out_path_len) {
     if (!profiles_initialized()) {
         LOG_ERROR("Called before initializing profile repo");
         return false;
@@ -161,7 +161,9 @@ bool profiles_repo_rename_temp_profile_dir(const char *temp_dir, bool partial, c
     }
 
     char ts[32];
-    utils_build_timestamp(ts, sizeof(ts));
+    utils_build_timestamp_dir(time, ts, sizeof(ts));
+
+    snprintf(out_dir, out_dir_len, "%s", ts);
 
     char download_path[PATH_MAX];
     char final_path[PATH_MAX];
@@ -186,10 +188,10 @@ bool profiles_repo_rename_temp_profile_dir(const char *temp_dir, bool partial, c
         return false;
     }
 
-    int len = snprintf(out, out_len, "%s", final_path);
+    int len = snprintf(out_path, out_path_len, "%s", final_path);
 
     if ((size_t)len < strlen(final_path)) {
-        LOG_WARN("Out value of '%s' was truncated from '%s'", out, final_path);
+        LOG_WARN("Out value of '%s' was truncated from '%s'", out_path, final_path);
     }
     
     return true;

--- a/src/utils.c
+++ b/src/utils.c
@@ -175,14 +175,20 @@ bool utils_create_directory(const char *path) {
     return false;
 }
 
-void utils_build_timestamp(char *out, size_t out_size) {
-    time_t now = time(NULL);
-
+void utils_build_timestamp_dir(time_t *t, char *out, size_t out_size) {
     struct tm tm_now;
 
-    localtime_r(&now, &tm_now);
+    gmtime_r(t, &tm_now);
 
     strftime(out, out_size, "%Y%m%d_%H%M%S", &tm_now);
+}
+
+void utils_build_iso_timestamp(time_t *t, char *out, size_t out_size) {
+    struct tm tm_now;
+
+    gmtime_r(t, &tm_now);
+
+    strftime(out, out_size, "%Y-%m-%dT%H:%M:%SZ", &tm_now);
 }
 
 void to_human_readable(const char *input, char *output, size_t out_size) {


### PR DESCRIPTION
Fixed `last_download` sensor to publish ISO timestamp as state (device_class=timestamp) and moved directory/path to attributes. removed invalid `value_template` that caused unknown state. 