### PR TITLE
Updated the MQTT commands to clear last error on success

### DIFF
--- a/include/ha_status.h
+++ b/include/ha_status.h
@@ -27,7 +27,19 @@ void status_set_status_message(const char *topic, const char *message);
  */
 void status_set_error(error_code_t code, const char *message_override);
 
+/**
+ * @brief Check if the error code or message has changed since the last time it was set. This can be used to avoid redundant logging.
+ * 
+ * @param code 
+ * @param message 
+ * @return true if the error code or message has changed, false otherwise
+ */
 bool status_error_changed(error_code_t code, const char *message);
+
+/**
+ * @brief Clear the current error state, setting the error code to 0 and the message to an empty string.
+ */
+void status_clear_error(void);
 
 /**
  * @brief  Set the name of the last applied profile. This is used for informational purposes

--- a/src/command.c
+++ b/src/command.c
@@ -70,6 +70,8 @@ void command_set_preset(const mqtt_router_ctx_t *ctx, const char *payload, size_
 
     ok = true;
 
+    status_clear_error();
+
 cleanup: 
     if (session) {
         ssh_session_destroy(session);
@@ -140,6 +142,8 @@ void command_apply_custom(const mqtt_router_ctx_t *ctx, const char *payload, siz
 
     ok = true;
 
+    status_clear_error();
+
 cleanup: 
     if (session) {
         ssh_session_destroy(session);
@@ -206,6 +210,8 @@ void command_download_assets(const mqtt_router_ctx_t *ctx, const char *payload, 
     goto cleanup;
   }
 
+  status_clear_error();
+
 cleanup:
   if (session) {
     ssh_session_destroy(session);
@@ -271,6 +277,7 @@ void command_test_config(const mqtt_router_ctx_t *ctx, const char *payload, size
         HA_ERRF(rc, "Failed to persist last_applied.json (profile=%s). State will not survive restart of service.", payload);
     }
      
+    status_clear_error();
 
 cleanup: 
     if (session) {
@@ -315,6 +322,8 @@ void command_play_sfx_preset(const mqtt_router_ctx_t *ctx, const char *payload, 
         HA_ERR(rc, "Failed to upload and play SFX");
         goto cleanup;
     }
+
+    status_clear_error();
 
 cleanup:
     if (session) {

--- a/src/ha_status.c
+++ b/src/ha_status.c
@@ -69,18 +69,46 @@ void status_set_error(error_code_t code, const char *message_override) {
 bool status_error_changed(error_code_t code, const char *message)
 {
     if (!message) {
-        return true;
+        return false;
     }
 
-    if ((int)code != g_last_error_code) {
-        return true;
-    }
-
-    if (strcmp(message, g_last_error_message) != 0) {
+    if ((int)code != g_last_error_code || strcmp(message, g_last_error_message) != 0) {
+        g_last_error_code = code;
+        strncpy(g_last_error_message, message, sizeof(g_last_error_message) - 1);
         return true;
     }
 
     return false;
+}
+
+void status_clear_error(void) {
+    const char *name = error_code_name(ERROR_NONE);
+
+    cJSON *root = cJSON_CreateObject();
+    if (!root) {
+        LOG_ERROR("Failed to allocate cJSON object for last_error.");
+        return;
+    }
+
+    cJSON_AddNumberToObject(root, "code", ERROR_NONE);
+    cJSON_AddStringToObject(root, "name", name);
+    cJSON_AddStringToObject(root, "message", "");
+
+    char *json = cJSON_PrintUnformatted(root);
+    
+    if (json) {
+        char topic[256];
+        ha_build_topic(topic, sizeof(topic), "last_error");
+        mqtt_publish(topic, json, 1, 1);
+    } else {
+        LOG_ERROR("Failed to serialize last_error JSON.");
+    }
+
+    g_last_error_code = 0;
+    g_last_error_message[0] = '\0';
+
+    cJSON_free(json);
+    cJSON_Delete(root);
 }
 
 void status_set_last_applied_profile(const char *profile) {


### PR DESCRIPTION
Updated the MQTT commands to clear the HA `last_error` entity on success to prevent a confusing UI state.

The entity status will now be blank.

Entity attributes

```
{
    "code": 0,
    "name": "ERROR_NONE",
    "message": ""
}
```

(#44)